### PR TITLE
Support for acme 0.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 readme = codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8').read()
 
 install_requires = [
-    'acme>=0.11,<0.12',
+    'acme>=0.15,<0.16',
     'cryptography',
     'pyOpenSSL',
     'pytz',

--- a/simp_le.py
+++ b/simp_le.py
@@ -1230,9 +1230,8 @@ def registered_client(args, existing_account_key):
     new_reg = messages.NewRegistration.from_data(email=args.email)
     try:
         regr = client.register(new_reg)
-    except messages.Error as error:
-        if error.detail != 'Registration key is already in use':
-            raise
+    except acme_errors.ConflictError as error:
+        logger.debug('Client already registered: %s', error.location)
     else:
         if regr.terms_of_service is not None:
             tos_hash = sha256_of_uri_contents(regr.terms_of_service)


### PR DESCRIPTION
Acme 0.15.0 throws an `errors.ConflictError` with the uri of the already registered account instead of a `messages.Error` containing the response json. This was introduced in: certbot/certbot@10bac10.

I am not sure if you want to raise the required acme version yet, but as I am using arch linux, which already provides acme 0.15, I thought this might be useful. I am also not sure if these are *all* the required changes for the new acme version, but at least all my cert-updates went through successfully.