### PR TITLE
Fix CI breakage for python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ addons:
     # it ourselves.
       - python2.6
       - python2.6-dev
+    # same for python 3.3
+      - python3.3
+      - python3.3-dev
     # python3.5 and python3.6 are not pre-installed on Travis,
     # https://github.com/travis-ci/travis-ci/issues/4794#issuecomment-143758799
     #


### PR DESCRIPTION
Python 3.3 builds are failing : https://travis-ci.org/buchdag/simp_le/builds/261004728

Fix is similar to e6864f6