### PR TITLE
Remove self-verification

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -1261,14 +1261,20 @@ def get_certr(client, csr, authorizations):
         invalid = [authzr for authzr in six.itervalues(error.updated)
                    if authzr.body.status == messages.STATUS_INVALID]
         if invalid:
-            logger.error('CA marked some of the authorizations as invalid, '
-                         'which likely means it could not access '
-                         'http://example.com/.well-known/acme-challenge/X. '
-                         'Did you set correct path in -d example.com:path '
-                         'or --default_root? Is there a warning log entry '
-                         'about unsuccessful self-verification? Are all your '
-                         'domains accessible from the internet? Failing '
-                         'authorizations: %s',
+            logger.error('CA marked some of the authorizations as invalid,'
+                         ' which likely means it could not access '
+                         'http://example.com/.well-known/acme-challenge/X.'
+                         ' Did you set correct path in -d example.com:path '
+                         'or --default_root? Are all your domains accessible '
+                         'from the internet? Please check your domains DNS '
+                         'answer, your host network/firewall setup and your '
+                         'webserver config. If a domain DNS have both A and '
+                         'AAAA fields setup, some CA such as Let\'s Encrypt '
+                         'will perform the challenge validation over IPv6. If'
+                         'you haven\'t setup correct CAA fields or if your DNS'
+                         ' provider does not support CAA, validation attempts'
+                         ' after september 8, 2017 will fail.'
+                         ' Failing authorizations: %s',
                          ', '.join(authzr.uri for authzr in invalid))
 
         raise Error('Challenge validation has failed, see error log.')
@@ -1296,14 +1302,6 @@ def persist_new_data(args, existing_data):
         challb = supported_challb(auth)
         response, validation = challb.response_and_validation(client.key)
         save_validation(roots[name], challb, validation)
-
-        verified = response.simple_verify(
-            challb.chall, name, client.key.public_key())
-        if not verified:
-            logger.warning('%s was not successfully self-verified. '
-                           'CA is likely to fail as well!', name)
-        else:
-            logger.info('%s was successfully self-verified', name)
 
         client.answer_challenge(challb, response)
 


### PR DESCRIPTION
This PR disable self-verification by default and make it available via a new `--self_verify` argument.

Reason for disabling it is that [it is considered unreliable by certbot devs themselves](https://github.com/certbot/certbot/issues/1586#issuecomment-186020863).

I witnessed with [JrCs/docker-letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) that indeed quite often the self verification fails while the CA challenge validation succeed, [making people search for a non existent issue](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion/issues/234). Plus the self-verification has little troubleshooting value, in verbose mode you just get the result of the failed GET request.