### PR TITLE
Add Docker support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 # configuration for https://travis-ci.org
+dist: trusty
+sudo: required
+
 language: python
 python:
   - "2.6"
@@ -13,9 +16,9 @@ matrix:
   include:
   - python: "2.7"
     env: TEST_SUITE=lint_suite
+  - python: "3.5"
+    env: TEST_SUITE=docker_suite
 
-services:
-  - docker
 addons:
   hosts:
     - le.wtf
@@ -25,7 +28,6 @@ addons:
     - boulder-rabbitmq
 
 install:
-  - pip install -e .
   - ./tests/install.sh $TEST_SUITE
 script:
   - ./tests/test-suite.sh $TEST_SUITE

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,11 @@ Installation
     ./venv.sh
     export PATH=$PWD/venv/bin:$PATH
 
+Usage with Docker
+-----------------
+
+If you want to use simp_le with Docker, have a look at `simp\_le for Docker`_.
+
 Help
 ----
 
@@ -88,6 +93,7 @@ Freenode)`_
 .. _Let’s Encrypt: https://letsencrypt.org
 .. _UNIX philosophy: https://en.wikipedia.org/wiki/Unix_philosophy
 .. _IRC (#simp\_le at Freenode): http://webchat.freenode.net?randomnick=1&channels=%23simp_le&prompt=1
+.. _simp\_le for Docker: docker
 
 .. |Build Status| image:: https://travis-ci.org/zenhack/simp_le.svg?branch=master
    :target: https://travis-ci.org/zenhack/simp_le

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM alpine:3.6
+
+MAINTAINER Ian Denhardt (@zenhack)
+
+ARG SIMP_LE_VERSION=master
+
+ENV PATH=/usr/local/bin:$PATH \
+    SIMP_LE_VERSION=${SIMP_LE_VERSION}
+
+RUN apk --no-cache add \
+        bash \
+        openssl \
+        python3 \
+    && apk --no-cache --virtual .build-deps add \
+        gcc \
+        git \
+        libffi-dev \
+        musl-dev \
+        openssl-dev \
+        py-pip \
+        python3-dev \
+    && pip3 install --no-cache-dir git+https://github.com/zenhack/simp_le.git@${SIMP_LE_VERSION} \
+    && apk --update --purge del .build-deps \
+    && rm /var/cache/apk/*
+
+COPY /entrypoint.sh /simp_le/entrypoint.sh
+
+WORKDIR /simp_le/certs
+
+ENTRYPOINT [ "/bin/bash", "/simp_le/entrypoint.sh" ]
+CMD [ "--help" ]

--- a/docker/Dockerfile.localbuild
+++ b/docker/Dockerfile.localbuild
@@ -1,0 +1,31 @@
+FROM alpine:3.6
+
+MAINTAINER Ian Denhardt (@zenhack)
+
+ENV PATH=/usr/local/bin:$PATH
+
+COPY . /simp_le/src 
+
+RUN apk --no-cache add \
+        bash \
+        openssl \
+        python3 \
+    && apk --no-cache --virtual .build-deps add \
+        gcc \
+        git \
+        libffi-dev \
+        musl-dev \
+        openssl-dev \
+        py-pip \
+        python3-dev \
+    && pip3 install --no-cache-dir /simp_le/src \
+    && rm -rf /simp_le/src \
+    && apk --update --purge del .build-deps \
+    && rm /var/cache/apk/*
+
+WORKDIR /simp_le/certs
+
+COPY /docker/entrypoint.sh /simp_le/entrypoint.sh
+
+ENTRYPOINT [ "/bin/bash", "/simp_le/entrypoint.sh" ]
+CMD [ "--help" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,68 @@
+simp_le for Docker
+========
+
+[![Build Status](https://travis-ci.org/zenhack/simp_le.svg)](https://travis-ci.org/zenhack/simp_le)
+
+Simple [Let’s Encrypt](https://letsencrypt.org/) client in a Docker container.
+
+This image is running on Alpine Linux and is around 80MB in size.
+
+N.B. this was originally a fork of https://github.com/kuba/simp_le, which is unmaintained and has some breakage due to bitrot. Thanks to @kuba for the original implementation.
+
+
+Manifesto
+---------
+
+For more info on simp_le aims, please read [its manifesto](https://github.com/zenhack/simp_le/blob/master/README.rst#manifesto).
+
+How to use this image
+--------
+
+The generated files are saved inside the container to `/simp_le/certs`, mount a volume there to get them.
+
+To obtain a certificate and private key for both `example.com` and `www.example.com` (assuming both domains are resolving to the host IP and a webserver is already running on the host, serving files from `/path/to/webroot`):
+
+```
+$ docker run --rm -v /path/to/webroot:/simp_le/www -v $PWD:/simp_le/certs zenhack/simp_le \
+    --email you@example.com -f account_key.json -f fullchain.pem -f key.pem \
+    -d example.com -d www.example.com --default_root /simp_le/www
+```
+
+- `-v /path/to/webroot:/simp_le/www` bind mount the local path `/path/to/webroot` to `/simp_le/www` inside the container, which is in turn used as simp_le default webroot with `--default_root`
+- `-v $PWD:/simp_le/certs` bind mount your local working directory to `/simp_le/certs` inside the container, where the requested files will be created.
+
+For more info run `$ docker run --rm zenhack/simp_le --help`.
+
+Example use with nginx container
+--------
+
+You can combine this container with `nginx` to quickly obtain certificates for your domains:
+
+```
+$ docker run -d --name nginx -p "80:80" -v webroot:/usr/share/nginx/html nginx:alpine
+$ docker run --rm --volumes-from nginx -v $PWD:/simp_le/certs zenhack/simp_le \
+    -email you@example.com -f account_key.json -f fullchain.pem -f key.pem \
+    -d example.com -d www.example.com --default_root /usr/share/nginx/html
+```
+
+Building the image from source
+--------
+
+For testing and development purpose, you can build this image from the cloned GitHub repository:
+
+```
+$ git clone https://github.com/zenhack/simp_le.git
+$ cd simp_le
+$ docker build -t zenhack/simp_le -f docker/Dockerfile.localbuild .
+```
+
+You can also build the image with a specific release of simp_le:
+
+```
+$ docker build --build-arg SIMP_LE_VERSION=0.5.0 -t zenhack/simp_le:0.5.0 docker/
+```
+
+Help
+--------
+
+Have a look at https://github.com/zenhack/simp_le/wiki/Examples

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# following recommendations for a consistent interface:
+# https://github.com/docker-library/official-images#consistency
+
+# if the first argument given to the entrypoint script is an
+# hyphenated flag, execute simp_le with this(those) flag(s),
+# else default to run whatever the user wanted like "bash"
+
+case "$1" in
+    -*) exec simp_le "$@" ;;
+    *) exec "$@" ;;
+esac

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -58,9 +58,18 @@ wait_for_boulder() {
 
 case $1 in
   lint_suite)
+    pip install -e .
     pip install pep8 pylint
     ;;
   simp_le_suite)
+    pip install -e .
+    setup_boulder
+    setup_webroot
+    wait_for_boulder
+    ;;
+  docker_suite)
+    docker build -t zenhack/simp_le -f docker/Dockerfile.localbuild .
+    git clone https://github.com/docker-library/official-images.git official-images
     setup_boulder
     setup_webroot
     wait_for_boulder

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -15,6 +15,11 @@ case $1 in
     simp_le -v --test
     simp_le -v --integration_test
     ;;
+  docker_suite)
+    official-images/test/run.sh zenhack/simp_le
+    docker run --rm zenhack/simp_le -v --test
+    docker run --rm --net="host" -v "${TRAVIS_BUILD_DIR}/public_html:/simp_le/certs/public_html" zenhack/simp_le -v --integration_test
+    ;;
 esac
 
 # vim: set ts=2 sw=2 et :


### PR DESCRIPTION
This PR add Docker support to the project and the relevant Travis tests.

The image is based on Alpine linux 3.6 with Python 3 and weight ~ 85MB

The following:

```
services:
  - docker
```

has been removed from the travis.yml file as [it isn't needed anymore with the Travis Trusty build environment](https://docs.travis-ci.com/user/reference/trusty/#Docker) and triggered a warning message.