### PR TITLE
Add basic domains sanitization to Vhost.decode()

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # Simple Let's Encrypt client.
 #
@@ -295,6 +294,7 @@ class Vhost(collections.namedtuple('Vhost', 'name root')):
 
     @classmethod
     def decode(cls, data):
+        # pylint: disable=anomalous-unicode-escape-in-string
         """Decode vhost and perform basic sanitization on the domain name:
         - raise an error if domain is not ASCII (Internationalized Domain
         Names are supported by Let's Encrypt using punycode).
@@ -306,7 +306,7 @@ class Vhost(collections.namedtuple('Vhost', 'name root')):
         Vhost(name='example.com', root=None)
 
         utf-8 test with example.china:
-        >>> Vhost.decode('例如.中国')
+        >>> Vhost.decode(u'\u4f8b\u5982.\u4e2d\u56fd')
         Traceback (most recent call last):
         ...
         Error: Non-ASCII domain names aren't supported. To issue


### PR DESCRIPTION
This PR aims to provide basic sanitization for domain names: 

- domains are converted to lowercase (fix for #25)
- raise an error if utf-8 characters are used, as LE does not directly support them

The utf-8 check is currently causing an unexpected doctest error on python 2.6 but not on 2.7, I haven't found a solution yet, any help is welcome:

```
ERROR: Doctest: simp_le.Vhost.decode
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/python/2.6.9/lib/python2.6/doctest.py", line 2158, in runTest
    test, out=new.write, clear_globs=False)
  File "/opt/python/2.6.9/lib/python2.6/doctest.py", line 1391, in run
    return self.__run(test, compileflags, out)
  File "/opt/python/2.6.9/lib/python2.6/doctest.py", line 1277, in __run
    got += _exception_traceback(exc_info)
  File "/opt/python/2.6.9/lib/python2.6/doctest.py", line 244, in _exception_traceback
    traceback.print_exception(exc_type, exc_val, exc_tb, file=excout)
  File "/opt/python/2.6.9/lib/python2.6/traceback.py", line 125, in print_exception
    print_tb(tb, limit, file)
  File "/opt/python/2.6.9/lib/python2.6/traceback.py", line 69, in print_tb
    line = linecache.getline(filename, lineno, f.f_globals)
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/linecache.py", line 14, in getline
    lines = getlines(filename, module_globals)
  File "/opt/python/2.6.9/lib/python2.6/doctest.py", line 1336, in __patched_linecache_getlines
    source = example.source.encode('ascii', 'backslashreplace')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 14: ordinal not in range(128)
```