### PR TITLE
Cleanup challenge files after use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,7 @@ represents the *next* (i.e. not yet released) version.
   spurrious warnings.
 * Improve argument sanity-checks and error messages.
 * Save account_key.json, even on failures
+* Clean temporary challenge files.
 * Upgrade acme to 0.19.x
 
 0.5.1

--- a/simp_le.py
+++ b/simp_le.py
@@ -1096,6 +1096,22 @@ def save_validation(root, challb, validation):
         validation_file.write(validation)
 
 
+def remove_validation(root, challb):
+    """Remove validation from webroot.
+
+    Args:
+      root: Webroot path.
+      challb: `acme.messages.ChallengeBody` with `http-01` challenge.
+    """
+    path = os.path.join(root, challb.path[1:])
+    try:
+        logger.debug('Removing validation file at %s', path)
+        os.remove(path)
+    except OSError as error:
+        logger.error('Could not remove validation '
+                     'file at %s : %s', path, error)
+
+
 def sha256_of_uri_contents(uri, chunk_size=10):
     """Get SHA256 of URI contents.
 
@@ -1431,6 +1447,10 @@ def persist_new_data(args, existing_data):
         persist_data(args, existing_data, new_data=IOPlugin.Data(
             account_key=client.key, key=None, cert=None, chain=None))
         raise error
+    finally:
+        for name, auth in six.iteritems(authorizations):
+            challb = supported_challb(auth)
+            remove_validation(roots[name], challb)
 
 
 def revoke(args):


### PR DESCRIPTION
Proposed fix for #5 

Not much to add, the challenge validation files are one shot so they're removed wether the validation succeed or fail.