### PR TITLE
Use pycodestyle instead of pep8

### DIFF
--- a/tests/install.sh
+++ b/tests/install.sh
@@ -59,7 +59,7 @@ wait_for_boulder() {
 case $1 in
   lint_suite)
     pip install -e .
-    pip install pep8 pylint
+    pip install pycodestyle pylint
     ;;
   simp_le_suite)
     pip install -e .

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -8,7 +8,7 @@ set -xe
 
 case $1 in
   lint_suite)
-    pep8 simp_le.py
+    pycodestyle simp_le.py
     pylint --disable=locally-disabled,fixme simp_le
     ;;
   simp_le_suite)


### PR DESCRIPTION
`pep8` was renamed to `pycodestyle` [at Guido van Rossum's request](https://github.com/PyCQA/pycodestyle/issues/466) about a year / year and a half ago.

Just happened to catch this [running some test](https://travis-ci.org/buchdag/simp_le/jobs/299261721).

```
pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.
```