### PR TITLE
Remove deprecated new_authz_uri from chall request

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -1432,8 +1432,7 @@ def persist_new_data(args, existing_data):
     client = registered_client(args, existing_data.account_key)
 
     authorizations = dict(
-        (vhost.name, client.request_domain_challenges(
-            vhost.name, new_authzr_uri=client.directory.new_authz))
+        (vhost.name, client.request_domain_challenges(vhost.name))
         for vhost in args.vhosts
     )
     if any(supported_challb(auth) is None


### PR DESCRIPTION
Caught the deprecation warning some time ago while running tests but I wasn't sure it should be removed. Thanks to @bmw for explaining it to me in details

https://letsencrypt.readthedocs.io/projects/acme/en/latest/api/client.html#acme.client.Client.request_challenges

certbot/certbot#4303