### PR TITLE
Correct failed authorisation error message

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -1414,10 +1414,11 @@ def get_certr(client, csr, authorizations):
                          "your webserver config. If a domain's DNS entry has "
                          "both A and AAAA fields set up, some CAs such as "
                          "Let's Encrypt will perform the challenge validation "
-                         "over IPv6. If you haven't setup correct CAA fields "
-                         "or if your DNS provider does not support CAA, "
-                         "validation attempts after september 8, 2017 will "
-                         "fail.  Failing authorizations: %s",
+                         "over IPv6. If your DNS provider does not answer "
+                         "correctly to CAA records request, Let's Encrypt "
+                         "won't issue a certificate for your domain (see "
+                         "https://letsencrypt.org/docs/caa/). Failing "
+                         "authorizations: %s",
                          ', '.join(authzr.uri for authzr in invalid))
 
         raise Error('Challenge validation has failed, see error log.')


### PR DESCRIPTION
Specifically the part about CAA DNS records, I got that wrong the first time:

- CAs **have** to check CAA records when issuing certificates since 08/09/2017 ...
- ... but having a CAA record set is **not required** to get a certificate from LE
- however a certificate won't be issued if the DNS provider of the domain fails when asked for a CAA record

https://letsencrypt.org/docs/caa/