### PR TITLE
Empty or corrupt files detection and error + code cleanup

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -439,7 +439,12 @@ class OpenSSLIOPlugin(IOPlugin):  # pylint: disable=abstract-method
 
     def load_key(self, data):
         """Load private key."""
-        return ComparablePKey(OpenSSL.crypto.load_privatekey(self.typ, data))
+        try:
+            key = OpenSSL.crypto.load_privatekey(self.typ, data)
+        except OpenSSL.crypto.Error:
+            raise Error("simp_le couldn't load a key from %s; "
+                        "the file might be empty or corrupt." % self.path)
+        return ComparablePKey(key)
 
     def dump_key(self, data):
         """Dump private key."""
@@ -447,8 +452,12 @@ class OpenSSLIOPlugin(IOPlugin):  # pylint: disable=abstract-method
 
     def load_cert(self, data):
         """Load certificate."""
-        return jose.ComparableX509(OpenSSL.crypto.load_certificate(
-            self.typ, data))
+        try:
+            cert = OpenSSL.crypto.load_certificate(self.typ, data)
+        except OpenSSL.crypto.Error:
+            raise Error("simp_le couldn't load a certificate from %s; "
+                        "the file might be empty or corrupt." % self.path)
+        return jose.ComparableX509(cert)
 
     def dump_cert(self, data):
         """Dump certificate."""

--- a/simp_le.py
+++ b/simp_le.py
@@ -82,29 +82,6 @@ class Error(Exception):
     """simp_le error."""
 
 
-_PEM_RE_LABELCHAR = r'[\x21-\x2c\x2e-\x7e]'
-_PEM_RE = re.compile(
-    (r"""
-^-----BEGIN\ ((?:%s(?:[- ]?%s)*)?)\s*-----$
-.*?
-^-----END\ \1-----\s*""" % (_PEM_RE_LABELCHAR, _PEM_RE_LABELCHAR)).encode(),
-    re.DOTALL | re.MULTILINE | re.VERBOSE)
-_PEMS_SEP = b'\n'
-
-
-def split_pems(buf):
-    r"""Split buffer comprised of PEM encoded (RFC 7468).
-
-    >>> x = b'\n-----BEGIN FOO BAR-----\nfoo\nbar\n-----END FOO BAR-----'
-    >>> len(list(split_pems(x * 3)))
-    3
-    >>> list(split_pems(b''))
-    []
-    """
-    for match in _PEM_RE.finditer(buf):
-        yield match.group(0)
-
-
 def gen_pkey(bits):
     """Generate a private key.
 
@@ -425,9 +402,25 @@ class OpenSSLIOPlugin(IOPlugin):  # pylint: disable=abstract-method
       typ: One of `OpenSSL.crypto.FILETYPE_*`, used in loading/dumping.
     """
 
+    _PEMS_SEP = b'\n'
+
     def __init__(self, typ=OpenSSL.crypto.FILETYPE_PEM, **kwargs):
         self.typ = typ
         super(OpenSSLIOPlugin, self).__init__(**kwargs)
+
+    @staticmethod
+    def split_pems(data):
+        """Split buffer comprised of PEM encoded (RFC 7468)."""
+        pem_re_labelchar = r'[\x21-\x2c\x2e-\x7e]'
+        pem_re = re.compile(
+            (r"""
+        ^-----BEGIN\ ((?:%s(?:[- ]?%s)*)?)\s*-----$
+        .*?
+        ^-----END\ \1-----\s*""" % (pem_re_labelchar,
+                                    pem_re_labelchar)).encode(),
+            re.DOTALL | re.MULTILINE | re.VERBOSE)
+        for match in pem_re.finditer(data):
+            yield match.group(0)
 
     def load_key(self, data):
         """Load private key."""
@@ -521,7 +514,7 @@ class ChainFile(FileIOPlugin, OpenSSLIOPlugin):
         return self.Data(account_key=False, key=False, cert=False, chain=True)
 
     def load_from_content(self, content):
-        pems = list(split_pems(content))
+        pems = list(self.split_pems(content))
         return self.Data(
             account_key=None,
             key=None,
@@ -531,7 +524,7 @@ class ChainFile(FileIOPlugin, OpenSSLIOPlugin):
 
     def save(self, data):
         pems = [self.dump_cert(cert) for cert in data.chain]
-        return self.save_to_file(_PEMS_SEP.join(pems))
+        return self.save_to_file(self._PEMS_SEP.join(pems))
 
 
 @IOPlugin.register(path='fullchain.pem', typ=OpenSSL.crypto.FILETYPE_PEM)
@@ -542,7 +535,7 @@ class FullChainFile(FileIOPlugin, OpenSSLIOPlugin):
         return self.Data(account_key=False, key=False, cert=True, chain=True)
 
     def load_from_content(self, content):
-        pems = list(split_pems(content))
+        pems = list(self.split_pems(content))
         return self.Data(
             account_key=None,
             key=None,
@@ -553,7 +546,7 @@ class FullChainFile(FileIOPlugin, OpenSSLIOPlugin):
     def save(self, data):
         pems = [self.dump_cert(data.cert)]
         pems.extend(self.dump_cert(cert) for cert in data.chain)
-        return self.save_to_file(_PEMS_SEP.join(pems))
+        return self.save_to_file(self._PEMS_SEP.join(pems))
 
 
 @IOPlugin.register(path='full.pem', typ=OpenSSL.crypto.FILETYPE_PEM)
@@ -564,7 +557,7 @@ class FullFile(FileIOPlugin, OpenSSLIOPlugin):
         return self.Data(account_key=False, key=True, cert=True, chain=True)
 
     def load_from_content(self, content):
-        pems = list(split_pems(content))
+        pems = list(self.split_pems(content))
         return self.Data(
             account_key=None,
             key=self.load_key(pems[0]),
@@ -575,7 +568,7 @@ class FullFile(FileIOPlugin, OpenSSLIOPlugin):
     def save(self, data):
         pems = [self.dump_key(data.key), self.dump_cert(data.cert)]
         pems.extend(self.dump_cert(cert) for cert in data.chain)
-        return self.save_to_file(_PEMS_SEP.join(pems))
+        return self.save_to_file(self._PEMS_SEP.join(pems))
 
 
 def load_pem_jwk(data):
@@ -653,7 +646,7 @@ class ExternalIOPlugin(OpenSSLIOPlugin):
 
     def load(self):
         """Call the external script to retrieve persisted data."""
-        pems = list(split_pems(self.get_output_or_fail('load')))
+        pems = list(self.split_pems(self.get_output_or_fail('load')))
         if not pems:
             return self.EMPTY_DATA
         persisted = self.persisted()
@@ -689,7 +682,7 @@ class ExternalIOPlugin(OpenSSLIOPlugin):
             logger.exception(error)
             raise Error(
                 'There was a problem executing external IO plugin script')
-        stdout, stderr = proc.communicate(_PEMS_SEP.join(output))
+        stdout, stderr = proc.communicate(self._PEMS_SEP.join(output))
         if stdout is not None:
             logger.debug('STDOUT: %s', stdout)
         if stderr is not None:
@@ -762,6 +755,18 @@ class UnitTestCase(unittest.TestCase):
             return False
         finally:
             logger.removeHandler(handler)
+
+
+class SplitPemsTest(UnitTestCase):
+    """split_pems static method test."""
+    # this is a test suite | pylint: disable=missing-docstring
+
+    def test_split_pems(self):
+        pem = b'\n-----BEGIN FOO BAR-----\nfoo\nbar\n-----END FOO BAR-----'
+        result = len(list(OpenSSLIOPlugin.split_pems(pem * 3)))
+        self.assertEqual(result, 3)
+        result = list(OpenSSLIOPlugin.split_pems(b''))
+        self.assertEqual(result, [])
 
 
 class PluginIOTestMixin(object):


### PR DESCRIPTION
This a first take at what's been discussed on #23 

730831b just reorder plugins and unit test classes to something a bit more readable and logical to me. There is zero code change on this commit.

3f11801 change the `AccountKey()` `KeyFile()` `CertFile()` `ChainFile()` `FullChainFile()` and `FullFile()` IOPlugins classes to be more similar. `FullChainFile()` is no longer a subclass of `ChainFile()`. The 3 "chain" plugins use a list built from the iterator created by `split_pems()` to allow testing its length (required to catch issues with those files later).

e078cee `split_pems()` is only used by subclasses of `OpenSSLIOPlugin()` so it make more sense to me to make it a method of this class rather than a function. The test performed by the function doctest has been moved to the unit test for the IOPlugins. I'm not 100% happy with this has it means it will be tested again for each plugin but that's the solution with the least amount of additional code (I can detail the other possibility I thought of).

27b822d same as above with `load_pem_jwk()` and `dump_pem_jwk()` functions being moved to methods of the `JWKIOPlugin()` class, for the same reasons.

158fef0 catch openssl errors on the `OpenSSLIOPlugin()` methods. This is enough for the "single files" plugins as empty or invalid content will result in openssl throwing an error.

3c5b4aa catch empty file for the "chain" plugins or files that didn't contain enough discrete pem encoded data + tests for this and the openssl error

001d80a fix for a new check added in Pylint 1.8.0 that `simp_le` was failing.