### PR TITLE
Docker multiarch support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,11 @@ matrix:
   - python: "2.7"
     env: TEST_SUITE=lint_suite
   - python: "3.5"
-    env: TEST_SUITE=docker_suite
+    env: ARCH=amd64 TEST_SUITE=docker_suite FROM=alpine:3.7 IMAGE=zenhack/simp_le:$ARCH
+  - python: "3.5"
+    env: ARCH=arm64 TEST_SUITE=docker_suite FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
+  - python: "3.5"
+    env: ARCH=arm TEST_SUITE=docker_suite FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
 
 addons:
   hosts:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM alpine:3.7
+ARG BUILD_FROM=alpine:3.7
+
+FROM $BUILD_FROM
 
 LABEL maintainer="Ian Denhardt (@zenhack)"
 
@@ -18,6 +20,9 @@ RUN apk update \
         openssl-dev \
         py-pip \
         python3-dev \
+        tzdata \
+    && cp /usr/share/zoneinfo/UTC /etc/localtime \
+    && echo "UTC" > /etc/timezone \
     && pip3 install --no-cache-dir /simp_le/src \
     && rm -rf /simp_le/src \
     && apk del --purge .build-deps \

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,3 +1,14 @@
 #!/bin/bash
 
-docker build --tag ${DOCKER_REPO}:${DOCKER_TAG} -f ./Dockerfile ..
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
+
+docker build --tag ${DOCKER_REPO}:amd64-${DOCKER_TAG} \
+             --file ./Dockerfile ..
+
+docker build --tag ${DOCKER_REPO}:arm64-${DOCKER_TAG} \
+             --build-arg BUILD_FROM=multiarch/alpine:arm64-v3.7 \
+             --file ./Dockerfile ..
+
+docker build --tag ${DOCKER_REPO}:arm-${DOCKER_TAG} \
+             --build-arg BUILD_FROM=multiarch/alpine:armhf-v3.7 \
+             --file ./Dockerfile ..

--- a/docker/hooks/post_push
+++ b/docker/hooks/post_push
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+curl -L https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64 -o ./manifest-tool
+chmod +x ./manifest-tool
+
+./manifest-tool push from-args \
+  --platforms linux/amd64,linux/arm64,linux/arm \
+  --template ${DOCKER_REPO}:ARCH-${DOCKER_TAG} \
+  --target ${DOCKER_REPO}:${DOCKER_TAG}

--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for ARCH in amd64 arm64 arm; do
+  docker push ${DOCKER_REPO}:${ARCH}-${DOCKER_TAG}
+done

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -67,7 +67,8 @@ case $1 in
     wait_for_boulder
     ;;
   docker_suite)
-    docker build -t zenhack/simp_le -f docker/Dockerfile .
+    [ $ARCH != "amd64" ] && docker run --rm --privileged multiarch/qemu-user-static:register --reset
+    docker build --build-arg BUILD_FROM="${FROM}" --tag "$IMAGE" --file docker/Dockerfile .
     git clone https://github.com/docker-library/official-images.git official-images
     setup_boulder
     setup_webroot

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -16,9 +16,9 @@ case $1 in
     simp_le -v --integration_test
     ;;
   docker_suite)
-    official-images/test/run.sh zenhack/simp_le
-    docker run --rm zenhack/simp_le -v --test
-    docker run --rm --net="host" -v "${TRAVIS_BUILD_DIR}/public_html:/simp_le/certs/public_html" zenhack/simp_le -v --integration_test
+    official-images/test/run.sh "$IMAGE"
+    docker run --rm "$IMAGE" -v --test
+    docker run --rm --net="host" -v "${TRAVIS_BUILD_DIR}/public_html:/simp_le/certs/public_html" "$IMAGE" -v --integration_test
     ;;
 esac
 


### PR DESCRIPTION
This PR is a continuation of #98 and brings tests and automated Docker builds for `arm` and `arm64` archs in addition to `x86_64`/`amd64`, plus the automated creation and push of a [Docker manifest](https://blog.docker.com/2017/11/multi-arch-all-the-things/).

The use of a Docker manifest mean that when you do `docker pull zenhack/simp_le` on one of the supported archs, Docker will automatically pull the correct layers for the archs it's running on. It's completely transparent for the user and most of the core images now support multiarch this way (vs previously having separate repos for other archs, like `arm32v6/alpine`).

This step is currently done with [Phil Estes's Manifest Tool](https://github.com/estesp/manifest-tool). This tool will be merged to the Docker CLI in a future version of Docker (probably soonish).

Testing and building `arm`/`arm64` on `amd64` only systems (Travis CI and Dockercloud) require [using Qemu](https://github.com/multiarch/qemu-user-static) and base `arm`/`arm64` images that include the Qemu binary. Scaleway provides exactly this for alpine through its [multiarch repo](https://github.com/multiarch/alpine).

I did a test against LE's endpoints on Raspberry Pi 3 running raspbian (armv7l), works perfectly fine.

The modification to the Dockerfile is to account for the `multiarch` images being GMT instead of UTC (and failing one of the test from the docker test suite if this is not corrected).