### PR TITLE
Update ACME to 0.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
@@ -15,11 +14,11 @@ matrix:
   include:
   - python: "2.7"
     env: TEST_SUITE=lint_suite
-  - python: "3.5"
+  - python: "3.6"
     env: ARCH=amd64 TEST_SUITE=docker_suite FROM=alpine:3.7 IMAGE=zenhack/simp_le:$ARCH
-  - python: "3.5"
+  - python: "3.6"
     env: ARCH=arm64 TEST_SUITE=docker_suite FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
-  - python: "3.5"
+  - python: "3.6"
     env: ARCH=arm TEST_SUITE=docker_suite FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
 
 addons:

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,12 @@ represents the *next* (i.e. not yet released) version.
 Releases occur approximately every two months, unless there is a pressing need
 to do otherwise (e.g. security & serious bug fixes).
 
+0.8.0 (Upcoming)
+++++++++++++++++
+
+* Drop official support for Python 2.6
+* Upgrade acme to 0.21.x
+
 0.7.0
 +++++
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,10 @@ here = os.path.abspath(os.path.dirname(__file__))
 readme = codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8').read()
 
 install_requires = [
-    'acme>=0.20,<0.21',
+    'acme>=0.21,<0.22',
     'cryptography',
+    # formerly known as acme.jose:
+    'josepy>=1.0.0',
     'pyOpenSSL',
     'pytz',
 ]

--- a/setup.py
+++ b/setup.py
@@ -12,19 +12,10 @@ install_requires = [
     'cryptography',
     # formerly known as acme.jose:
     'josepy>=1.0.0',
+    'mock',
     'pyOpenSSL',
     'pytz',
 ]
-
-if sys.version_info < (2, 7):
-    install_requires.extend([
-        'argparse',
-        'mock<1.1.0',
-    ])
-else:
-    install_requires.extend([
-        'mock',
-    ])
 
 tests_require = [
     'pycodestyle',
@@ -59,7 +50,6 @@ setuptools.setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/simp_le.py
+++ b/simp_le.py
@@ -47,6 +47,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+import josepy as jose
 import mock
 import OpenSSL
 import pytz
@@ -55,7 +56,6 @@ from acme import client as acme_client
 from acme import crypto_util
 from acme import challenges
 from acme import errors as acme_errors
-from acme import jose
 from acme import messages
 
 


### PR DESCRIPTION
A few more changes than usual:

- acme.jose has been moved to a separate package named [josepy](https://github.com/certbot/josepy)
- python 2.6 is being deprecated by acme like 3.3 was last year