### PR TITLE
Fix test suite after Boulder update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ addons:
   hosts:
     - le.wtf
     - le2.wtf
-    - boulder
-    - boulder-mysql
-    - boulder-rabbitmq
 
 install:
   - ./tests/install.sh $TEST_SUITE

--- a/simp_le.py
+++ b/simp_le.py
@@ -1657,13 +1657,13 @@ class IntegrationTests(unittest.TestCase):
 
     Prerequisites:
     - /etc/hosts:127.0.0.1 le.wtf
-    - Boulder running on localhost:4000
+    - Boulder running on 10.77.77.1:4000 (with Docker)
     - Boulder verifying http-01 on port 5002
     """
     # this is a test suite | pylint: disable=missing-docstring
 
-    SERVER = 'http://localhost:4000/directory'
     PORT = 5002
+    SERVER = 'http://10.77.77.1:4000/directory'
 
     @classmethod
     def _run(cls, cmd):

--- a/simp_le.py
+++ b/simp_le.py
@@ -1662,7 +1662,6 @@ class IntegrationTests(unittest.TestCase):
     """
     # this is a test suite | pylint: disable=missing-docstring
 
-    PORT = 5002
     SERVER = 'http://10.77.77.1:4000/directory'
 
     @classmethod

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -9,13 +9,6 @@ set -xe
 SERVER='http://10.77.77.1:4000/directory'
 PORT=5002
 
-here=$(dirname "$0")
-
-# Would just use realpath, but it's not available on travis apparently:
-cd $(dirname $0)
-here=$PWD
-cd -
-
 setup_docker_compose () {
   curl -L https://github.com/docker/compose/releases/download/1.21.1/docker-compose-"$(uname -s)"-"$(uname -m)" > docker-compose.temp
   chmod +x docker-compose.temp

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -6,7 +6,7 @@
 # from some of the commands in this file (#39).
 set -xe
 
-SERVER=http://localhost:4000/directory
+SERVER='http://10.77.77.1:4000/directory'
 PORT=5002
 
 here=$(dirname "$0")
@@ -15,6 +15,12 @@ here=$(dirname "$0")
 cd $(dirname $0)
 here=$PWD
 cd -
+
+setup_docker_compose () {
+  curl -L https://github.com/docker/compose/releases/download/1.21.1/docker-compose-"$(uname -s)"-"$(uname -m)" > docker-compose.temp
+  chmod +x docker-compose.temp
+  sudo mv docker-compose.temp /usr/local/bin/docker-compose
+}
 
 setup_boulder() {
   # Per the boulder README:
@@ -27,6 +33,7 @@ setup_boulder() {
   docker-compose pull
   docker-compose build
   docker-compose run \
+    --use-aliases \
     -e FAKE_DNS=$docker_ip \
     --service-ports \
     boulder &
@@ -62,6 +69,7 @@ case $1 in
     ;;
   simp_le_suite)
     pip install -e .
+    setup_docker_compose
     setup_boulder
     setup_webroot
     wait_for_boulder
@@ -70,6 +78,7 @@ case $1 in
     [ $ARCH != "amd64" ] && docker run --rm --privileged multiarch/qemu-user-static:register --reset
     docker build --build-arg BUILD_FROM="${FROM}" --tag "$IMAGE" --file docker/Dockerfile .
     git clone https://github.com/docker-library/official-images.git official-images
+    setup_docker_compose
     setup_boulder
     setup_webroot
     wait_for_boulder


### PR DESCRIPTION
The test suite is currently broken due to upstream changes in Boulder: https://travis-ci.org/buchdag/simp_le/builds/377389795

This PR fix the test suite with the current version of Boulder.