### PR TITLE
Acme 0.34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
     env: ARCH=arm64 TEST_SUITE=docker_suite FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
   - python: "3.6"
     env: ARCH=arm TEST_SUITE=docker_suite FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
+  allow_failures:
+  - env: ARCH=arm64 TEST_SUITE=docker_suite FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
+  - env: ARCH=arm TEST_SUITE=docker_suite FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
 
 addons:
   hosts:

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,12 @@ represents the *next* (i.e. not yet released) version.
 Releases occur approximately every two months, unless there is a pressing need
 to do otherwise (e.g. security & serious bug fixes).
 
-0.14.0 (Upcoming)
+0.15.0 (Upcoming)
+++++++
+
+* Upgrade acme to 0.34.x
+
+0.14.0
 ++++++
 
 * Upgrade acme to 0.33.x

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = [
     # * https://github.com/pypa/pip/issues/988
     'idna<2.8',
 
-    'acme>=0.33,<0.34',
+    'acme>=0.34.2,<0.35',
     'cryptography',
     # formerly known as acme.jose:
     'josepy',


### PR DESCRIPTION
In addition to the version bump, this PR also changes the Travis test suite to allow failure of the two Docker ARM test suites, as they currently fail due to [CVE-2019-5021](https://talosintelligence.com/vulnerability_reports/TALOS-2019-0782) not being patched yet in multiarch/alpine.