### PR TITLE
Fix ACME v2 client registration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,11 @@ represents the *next* (i.e. not yet released) version.
 Releases occur approximately every two months, unless there is a pressing need
 to do otherwise (e.g. security & serious bug fixes).
 
+0.15.1 (Upcoming)
+++++++
+
+* Fix an ACME v2 protocol non-conformity
+
 0.15.0
 ++++++
 

--- a/simp_le.py
+++ b/simp_le.py
@@ -1327,7 +1327,11 @@ def registered_client(args, existing_account_key, existing_account_reg):
     """Return an ACME v2 client from account key and registration.
     Register a new account or recover missing registration if necessary."""
     key = check_or_generate_account_key(args, existing_account_key)
-    net = acme_client.ClientNetwork(key, user_agent=args.user_agent)
+    net = acme_client.ClientNetwork(
+        key=key,
+        account=existing_account_reg,
+        user_agent=args.user_agent
+    )
     directory = messages.Directory.from_json(net.get(args.server).json())
     client = acme_client.ClientV2(directory, net=net)
 
@@ -1349,9 +1353,7 @@ def registered_client(args, existing_account_key, existing_account_reg):
             logger.debug('Client already registered: %s', error.location)
             existing_reg = messages.RegistrationResource(uri=error.location)
             existing_reg = client.query_registration(existing_reg)
-            client.update_registration(existing_reg)
-    else:
-        client.update_registration(existing_account_reg)
+            client.net.account = existing_reg
 
     return client
 


### PR DESCRIPTION
This fix an issue that came to light while trying to switch the test suite from `boulder` to `pebble`.

While the previous code worked with current `boulder` version, it's actually not ACME v2 compliant and caused POST-as-GET errors with Pebble. That indicates potential real world breakage starting November 1st when POST-as-GET becomes mandatory : https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380