### PR TITLE
CI: run tests against pebble

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,16 @@ matrix:
   - python: "3.7"
     env: TEST_SUITE=lint_suite
   - python: "3.7"
-    env: ARCH=amd64 TEST_SUITE=docker_suite ACME_CA=boulder FROM=alpine:3.7 IMAGE=zenhack/simp_le:$ARCH
+    env: TEST_SUITE=docker_suite ACME_CA=boulder ARCH=amd64 FROM=alpine:3.7 IMAGE=zenhack/simp_le:$ARCH
   - python: "3.7"
-    env: ARCH=amd64 TEST_SUITE=docker_suite ACME_CA=pebble FROM=alpine:3.7 IMAGE=zenhack/simp_le:$ARCH
+    env: TEST_SUITE=docker_suite ACME_CA=pebble ARCH=amd64 FROM=alpine:3.7 IMAGE=zenhack/simp_le:$ARCH
   - python: "3.7"
-    env: ARCH=arm64 TEST_SUITE=docker_suite ACME_CA=pebble FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
+    env: TEST_SUITE=docker_suite ACME_CA=pebble ARCH=arm64 FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
   - python: "3.7"
-    env: ARCH=arm TEST_SUITE=docker_suite ACME_CA=pebble FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
+    env: TEST_SUITE=docker_suite ACME_CA=pebble ARCH=arm FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
   allow_failures:
-  - env: ARCH=arm64 TEST_SUITE=docker_suite ACME_CA=pebble FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
-  - env: ARCH=arm TEST_SUITE=docker_suite ACME_CA=pebble FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
+  - env: TEST_SUITE=docker_suite ACME_CA=pebble ARCH=arm64 FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
+  - env: TEST_SUITE=docker_suite ACME_CA=pebble ARCH=arm FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
 
 addons:
   hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,33 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - TEST_SUITE=simp_le_suite
+  - TEST_SUITE=simp_le_suite ACME_CA=boulder
 matrix:
   fast_finish: true
   include:
+  - python: "3.5"
+    env: TEST_SUITE=simp_le_suite ACME_CA=pebble
+  - python: "3.6"
+    env: TEST_SUITE=simp_le_suite ACME_CA=pebble
+  - python: "3.7"
+    env: TEST_SUITE=simp_le_suite ACME_CA=pebble
   - python: "3.7"
     env: TEST_SUITE=lint_suite
   - python: "3.7"
-    env: ARCH=amd64 TEST_SUITE=docker_suite FROM=alpine:3.7 IMAGE=zenhack/simp_le:$ARCH
+    env: ARCH=amd64 TEST_SUITE=docker_suite ACME_CA=boulder FROM=alpine:3.7 IMAGE=zenhack/simp_le:$ARCH
   - python: "3.7"
-    env: ARCH=arm64 TEST_SUITE=docker_suite FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
+    env: ARCH=amd64 TEST_SUITE=docker_suite ACME_CA=pebble FROM=alpine:3.7 IMAGE=zenhack/simp_le:$ARCH
   - python: "3.7"
-    env: ARCH=arm TEST_SUITE=docker_suite FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
+    env: ARCH=arm64 TEST_SUITE=docker_suite ACME_CA=pebble FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
+  - python: "3.7"
+    env: ARCH=arm TEST_SUITE=docker_suite ACME_CA=pebble FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
   allow_failures:
-  - env: ARCH=arm64 TEST_SUITE=docker_suite FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
-  - env: ARCH=arm TEST_SUITE=docker_suite FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
+  - env: ARCH=arm64 TEST_SUITE=docker_suite ACME_CA=pebble FROM=multiarch/alpine:arm64-v3.7 IMAGE=zenhack/simp_le:$ARCH
+  - env: ARCH=arm TEST_SUITE=docker_suite ACME_CA=pebble FROM=multiarch/alpine:armhf-v3.7 IMAGE=zenhack/simp_le:$ARCH
 
 addons:
   hosts:
+    - pebble
     - le.wtf
     - le2.wtf
 

--- a/simp_le.py
+++ b/simp_le.py
@@ -1206,7 +1206,7 @@ def integration_test(args):
     suite = unittest.TestSuite()
     test_names = unittest.TestLoader().getTestCaseNames(IntegrationTests)
     for test_name in test_names:
-        suite.addTest(IntegrationTests(test_name, args.ca_bundle))
+        suite.addTest(IntegrationTests(test_name, args.ca_bundle, args.server))
     return test_suite(args, suite)
 
 
@@ -1642,15 +1642,15 @@ class IntegrationTests(unittest.TestCase):
 
     Prerequisites:
     - /etc/hosts:127.0.0.1 le.wtf
-    - Boulder running on 10.77.77.1:4001 (with Docker)
+    - Boulder URL passed to simp_le with --server
     - Boulder verifying http-01 on port 5002
     """
     # this is a test suite | pylint: disable=missing-docstring
-    def __init__(self, testname, ca_bundle):
+
+    def __init__(self, testname, ca_bundle, server):
         super(IntegrationTests, self).__init__(testname)
         self.ca_bundle = ca_bundle
-
-    SERVER = 'http://10.77.77.1:4001/directory'
+        self.server = server
 
     @classmethod
     def _run(cls, cmd):
@@ -1685,7 +1685,7 @@ class IntegrationTests(unittest.TestCase):
 
     def test_it(self):
         webroot = os.path.join(os.getcwd(), 'public_html')
-        cmd = ["simp_le", "-v", "--server", (self.SERVER),
+        cmd = ["simp_le", "-v", "--server", (self.server),
                "-f", "account_key.json", "-f", "account_reg.json",
                "-f", "key.pem", "-f", "full.pem"]
         if self.ca_bundle is not None:
@@ -1708,7 +1708,7 @@ class IntegrationTests(unittest.TestCase):
             # NB get_stats() would fail if file didn't exist
             self.assertEqual(initial_stats, self.get_stats(*files))
 
-            cmd_revoke = ["simp_le", "-v", "--server", (self.SERVER),
+            cmd_revoke = ["simp_le", "-v", "--server", (self.server),
                           "--revoke", "-f", "account_key.json",
                           "-f", "account_reg.json", "-f", "full.pem"]
             if self.ca_bundle is not None:

--- a/simp_le.py
+++ b/simp_le.py
@@ -1641,9 +1641,10 @@ class IntegrationTests(unittest.TestCase):
     """Integrations tests with Boulder.
 
     Prerequisites:
-    - /etc/hosts:127.0.0.1 le.wtf
-    - Boulder URL passed to simp_le with --server
-    - Boulder verifying http-01 on port 5002
+    - /etc/hosts:127.0.0.1 le.wtf le2.wtf pebble
+    - Boulder or Pebble URL passed to simp_le with --server
+    - Boulder or Pebble verifying http-01 on port 5002
+    - Path to Boulder or Pebble HTTPS CA passed with --ca_bundle if needed
     """
     # this is a test suite | pylint: disable=missing-docstring
 

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -36,11 +36,7 @@ setup_boulder() {
 setup_webroot() {
   mkdir public_html
   cd public_html
-  if python -V 2>&1 | grep -q "Python 3."; then
-    python -m http.server ${PORT?} &
-  else
-    python -m SimpleHTTPServer ${PORT?} &
-  fi
+  python -m http.server ${PORT?} &
   cd -
 }
 

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -6,7 +6,6 @@
 # from some of the commands in this file (#39).
 set -xe
 
-SERVER='http://10.77.77.1:4001/directory'
 PORT=5002
 
 setup_docker_compose () {
@@ -47,7 +46,7 @@ setup_webroot() {
 
 wait_for_boulder() {
   i=0
-  while ! curl ${SERVER?} >/dev/null 2>&1; do
+  while ! curl http://10.77.77.1:4001/directory >/dev/null 2>&1; do
     if [ $(($i * 5)) -gt $((5 * 60)) ]; then
       printf 'Boulder has not started for 5 minutes, timing out.\n'
       exit 1

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -33,23 +33,64 @@ setup_boulder() {
   cd -
 }
 
-setup_webroot() {
-  mkdir public_html
-  cd public_html
-  python -m http.server ${PORT?} &
-  cd -
+setup_pebble() {
+  docker network create --driver=bridge --subnet=10.30.50.0/24 acmenet
+  curl https://raw.githubusercontent.com/letsencrypt/pebble/master/test/certs/pebble.minica.pem > ${TRAVIS_BUILD_DIR}/pebble.minica.pem
+  cat ${TRAVIS_BUILD_DIR}/pebble.minica.pem
+
+  docker run \
+    --name pebble \
+    --network acmenet \
+    --ip="10.30.50.2" \
+    --publish 14000:14000 \
+    letsencrypt/pebble:v2.1.0 \
+    pebble -config /test/config/pebble-config.json -dnsserver 10.30.50.3:8053 &
+
+  docker run \
+    --name challtestserv \
+    --network acmenet \
+    --ip="10.30.50.3" \
+    --publish 8055:8055 \
+    letsencrypt/pebble-challtestsrv:v2.1.0 \
+    pebble-challtestsrv -defaultIPv6 "" -defaultIPv4 10.30.50.1 &
 }
 
-wait_for_boulder() {
+setup_acme_server() {
+  case $ACME_CA in
+    boulder)
+      setup_boulder
+      ;;
+    pebble)
+      setup_pebble
+      ;;
+  esac
+}
+
+wait_for_acme_server() {
   i=0
-  while ! curl http://10.77.77.1:4001/directory >/dev/null 2>&1; do
+  case $ACME_CA in
+    boulder)
+      url='http://10.77.77.1:4001/directory'
+      ;;
+    pebble)
+      url='https://pebble:14000/dir'
+      ;;
+  esac
+  while ! curl -k $url >/dev/null 2>&1; do
     if [ $(($i * 5)) -gt $((5 * 60)) ]; then
-      printf 'Boulder has not started for 5 minutes, timing out.\n'
+      printf "$ACME_CA has not started for 5 minutes, timing out.\n"
       exit 1
     fi
     i=$((i + 1))
     sleep 5
   done
+}
+
+setup_webroot() {
+  mkdir public_html
+  cd public_html
+  python -m http.server ${PORT?} &
+  cd -
 }
 
 case $1 in
@@ -59,18 +100,18 @@ case $1 in
   simp_le_suite)
     pip install -e .
     setup_docker_compose
-    setup_boulder
+    setup_acme_server
     setup_webroot
-    wait_for_boulder
+    wait_for_acme_server
     ;;
   docker_suite)
     [ $ARCH != "amd64" ] && docker run --rm --privileged multiarch/qemu-user-static:register --reset
     docker build --build-arg BUILD_FROM="${FROM}" --tag "$IMAGE" --file docker/Dockerfile .
     git clone https://github.com/docker-library/official-images.git official-images
     setup_docker_compose
-    setup_boulder
+    setup_acme_server
     setup_webroot
-    wait_for_boulder
+    wait_for_acme_server
     ;;
 esac
 

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -13,12 +13,15 @@ case $1 in
     ;;
   simp_le_suite)
     simp_le -v --test
-    simp_le -v --integration_test
+    simp_le -v --integration_test --server http://10.77.77.1:4001/directory
     ;;
   docker_suite)
     official-images/test/run.sh "$IMAGE"
     docker run --rm "$IMAGE" -v --test
-    docker run --rm --net="host" -v "${TRAVIS_BUILD_DIR}/public_html:/simp_le/certs/public_html" "$IMAGE" -v --integration_test
+    docker run --rm \
+      --net="host" \
+      -v "${TRAVIS_BUILD_DIR}/public_html:/simp_le/certs/public_html" \
+      "$IMAGE" -v --integration_test --server http://10.77.77.1:4001/directory
     ;;
 esac
 

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -6,6 +6,41 @@
 # from some of the commands in this file (#39).
 set -xe
 
+run_host_integration_test(){
+  case $ACME_CA in
+    boulder)
+      simp_le -v --integration_test \
+        --server http://10.77.77.1:4001/directory
+      ;;
+    pebble)
+      simp_le -v --integration_test \
+        --ca_bundle "${TRAVIS_BUILD_DIR}/pebble.minica.pem" \
+        --server https://pebble:14000/dir
+      ;;
+  esac
+}
+
+run_docker_integration_test(){
+  case $ACME_CA in
+    boulder)
+      docker run --rm \
+        --network host \
+        --volume "${TRAVIS_BUILD_DIR}/public_html:/simp_le/certs/public_html" \
+        "$IMAGE" -v --integration_test \
+        --server http://10.77.77.1:4001/directory
+      ;;
+    pebble)
+      docker run --rm \
+        --network acmenet \
+        --volume "${TRAVIS_BUILD_DIR}/public_html:/simp_le/certs/public_html" \
+        --volume "${TRAVIS_BUILD_DIR}/pebble.minica.pem:/pebble.minica.pem" \
+        "$IMAGE" -v --integration_test \
+        --server https://pebble:14000/dir \
+        --ca_bundle /pebble.minica.pem
+      ;;
+  esac
+}
+
 case $1 in
   lint_suite)
     pycodestyle simp_le.py
@@ -13,15 +48,12 @@ case $1 in
     ;;
   simp_le_suite)
     simp_le -v --test
-    simp_le -v --integration_test --server http://10.77.77.1:4001/directory
+    run_host_integration_test
     ;;
   docker_suite)
     official-images/test/run.sh "$IMAGE"
     docker run --rm "$IMAGE" -v --test
-    docker run --rm \
-      --net="host" \
-      -v "${TRAVIS_BUILD_DIR}/public_html:/simp_le/certs/public_html" \
-      "$IMAGE" -v --integration_test --server http://10.77.77.1:4001/directory
+    run_docker_integration_test
     ;;
 esac
 


### PR DESCRIPTION
As discussed in #123, this PR runs integration tests against Pebble rather than Boulder.

[As suggested by Pebble's doc](https://github.com/letsencrypt/pebble#avoiding-client-https-errors), it adds the following feature to make testing with Pebble possible:

> client should offer a runtime option to specify a list of trusted root CAs

In this PR Pebble does not run in [strict mode](https://github.com/letsencrypt/pebble#strict-mode) because the `acme` Python module around which `simp_le` is built [is not currently compliant with RFC8555](https://github.com/certbot/certbot/issues/7177).

@zenhack If you think we should test against both Pebble and Boulder, let me know.