### PR TITLE
Make venv.sh create a python3 virtualenv

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,21 +4,14 @@
 bootstrap_deb () {
   apt-get update
 
-  # virtualenv binary can be found in different packages depending on
-  # distro version
-  virtualenv_bin_pkg="virtualenv"
-  if ! apt-cache show -qq "${virtualenv_bin_pkg}" >/dev/null 2>&1; then
-    virtualenv_bin_pkg="python-virtualenv"
-  fi
-
   apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     libssl-dev \
     libffi-dev \
-    python \
-    python-dev \
-    "${virtualenv_bin_pkg}"
+    python3 \
+    python3-dev \
+    python3-virtualenv
 }
 
 bootstrap_rpm () {

--- a/venv.sh
+++ b/venv.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-virtualenv -p python3 --no-site-packages venv
+python3 -m virtualenv -p python3 --no-site-packages venv
 export PATH="$PWD/venv/bin:$PATH"  # #49, activate script requires bash
 for pkg in pip setuptools wheel
 do

--- a/venv.sh
+++ b/venv.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-virtualenv --no-site-packages venv
+virtualenv -p python3 --no-site-packages venv
 export PATH="$PWD/venv/bin:$PATH"  # #49, activate script requires bash
 for pkg in pip setuptools wheel
 do


### PR DESCRIPTION
Also, completely switch to python3 in bootstrap.sh

v0.15 officially drops support for python2, but most Debian-like LTS-style systems will still have it installed and default to it when using `virtualenv`. This way we can be sure that the provided install path will be running on python3

This PR doesn't address the `yum` world, as python3 doesn't seem to be in core, and I don't have the background to know what the standard install path for it is there.

Also closes #21 