### PR TITLE
Account registration test updates

### DIFF
--- a/tests/install.sh
+++ b/tests/install.sh
@@ -22,7 +22,7 @@ setup_boulder() {
   git clone https://github.com/letsencrypt/boulder \
     $GOPATH/src/github.com/letsencrypt/boulder
   cd $GOPATH/src/github.com/letsencrypt/boulder
-  git checkout release-2019-06-17
+  git checkout release-2019-10-13
   docker-compose pull
   docker-compose build
   docker-compose run \


### PR DESCRIPTION
This PR update the integration test to take into consideration the account registration file.

The integration test now check that the account registration file is correctly recovered if it was removed from the current working directory, and check the account registration file status along with the other files.

The version of Boulder used in the Travis integration test has also been updated to `2019-10-13`.

Does this need to be added to the changelog too ?