### PR TITLE
split_pems: handle CRLF line endings correctly.

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -913,15 +913,14 @@ class SplitPemsTest(UnitTestCase):
 
     def _check_line_break(self, sep):
         """Helper for making sure various line separators work."""
-        x = sep.join([
+        data = sep.join([
             b'',
             b'-----BEGIN FOO BAR-----',
             b'foo',
             b'bar',
             b'-----END FOO BAR-----',
         ])
-        print('%r' % x)
-        self.assertEqual(len(list(split_pems(x * 3))), 3)
+        self.assertEqual(len(list(split_pems(data * 3))), 3)
 
 
 def create_parser():


### PR DESCRIPTION
This should fix #133. In addition to the tests in the commit I also ran this on the log output @OscarKolsrud sent me. @OscarKolsrud, could you check that this works for you?