### PR TITLE
Update venv.sh

### DIFF
--- a/venv.sh
+++ b/venv.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-python3 -m virtualenv -p python3 --no-site-packages venv
+python3 -m virtualenv -p python3 venv
 export PATH="$PWD/venv/bin:$PATH"  # #49, activate script requires bash
 for pkg in pip setuptools wheel
 do


### PR DESCRIPTION
Current code produces error on more fresh python/virtualenv installations:
```
virtualenv: error: unrecognized arguments: --no-site-packages
```

https://stackoverflow.com/a/60783839/1758892

> --no-site-packages is the default for virtualenv (and has been for like 5 years?) 

> it appears in virtualenv>=20 that this option was removed