### PR TITLE
Fix crashing simp_le.py because of missing six package

### DIFF
--- a/venv.sh
+++ b/venv.sh
@@ -4,7 +4,7 @@ set -e
 
 python3 -m virtualenv -p python3 venv
 export PATH="$PWD/venv/bin:$PATH"  # #49, activate script requires bash
-for pkg in pip setuptools wheel
+for pkg in pip setuptools wheel six
 do
   pip install -U "${pkg?}"
 done


### PR DESCRIPTION
In our Debian 10 environment script `simple.py` started to crash due to missing six module in `venv`.

```
Traceback (most recent call last):
  File "/usr/local/sbin/simp_le", line 33, in <module>
    sys.exit(load_entry_point('simp-le-client', 'console_scripts', 'simp_le')())
  File "/opt/simp_le/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/opt/simp_le/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2793, in load_entry_point
    return ep.load()
  File "/opt/simp_le/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2411, in load
    return self.resolve()
  File "/opt/simp_le/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2417, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/opt/simp_le/simp_le.py", line 43, in <module>
    import six
```

We have mitigated the problem by installing six package in `venv.sh`