### PR TITLE
Change generated CSR version to 0

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -154,10 +154,7 @@ def gen_csr(pkey, domains, sig_hash='sha256'):
     ])
     req.set_pubkey(pkey)
 
-    # pre-1.0.2 version of OpenSSL the generated CSR will contain a
-    # zero-length Version field which will cause some strict parsers
-    # (e.g. the one in Golang, used by Boulder) to fail.
-    req.set_version(2)
+    req.set_version(0)
 
     req.sign(pkey, sig_hash)
     return req


### PR DESCRIPTION
CSRs are PKCS#10 documents, and the standard does not define versions above 0.

Reference: https://github.com/certbot/certbot/pull/9334