### PR TITLE
Update to python-acme 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = [
     # * https://github.com/pypa/pip/issues/988
     'idna<2.8',
 
-    'acme>=1.6,<2.0',
+    'acme>=2.0,<3.0',
     'cryptography',
     # formerly known as acme.jose:
     'josepy',

--- a/simp_le.py
+++ b/simp_le.py
@@ -1052,16 +1052,9 @@ def supported_challb(authorization):
     Returns:
       `acme.messages.ChallengeBody` with `http-01` challenge or `None`.
     """
-    if authorization.body.combinations is None:
-        for challenge in authorization.body.challenges:
-            if isinstance(challenge.chall, challenges.HTTP01):
-                return challenge
-    else:
-        for combo in authorization.body.combinations:
-            first_challb = authorization.body.challenges[combo[0]]
-            if len(combo) == 1 and isinstance(
-                    first_challb.chall, challenges.HTTP01):
-                return first_challb
+    for challenge in authorization.body.challenges:
+        if isinstance(challenge.chall, challenges.HTTP01):
+            return challenge
     return None
 
 


### PR DESCRIPTION
python-acme 2 removed the Authorization.combinations interface, but that was already deprecated and code to support the new interface added in cf9c3ba68c32abbb693973aece3b311e2e02392a with #119.

Note that I didn't run the integration tests (seems to be optimized for CI, and I don't have the time currently to replicate this offline), but I could successfully issue certificates with this change and python-acme 2.3 (as currently packaged in arch linux).